### PR TITLE
Simplify and tidy up after various fetch-mock updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,11 @@
 var _ = require('lodash')
 var Promise = require('bluebird')
 
-var IS_BROWSER = typeof window !== 'undefined'
-
-if (IS_BROWSER) {
-	// The browser mock assumes global fetch prototypes exist
-	// Can improve after https://github.com/wheresrhys/fetch-mock/issues/158
-	var realFetchModule = require('fetch-ponyfill')({ Promise: Promise })
-	_.assign(window, _.pick(realFetchModule, 'Headers', 'Request', 'Response'))
-}
-
 var fetchMock = require('fetch-mock').sandbox(Promise)
-
-// Promise sandbox config needs a little help. See:
-// https://github.com/wheresrhys/fetch-mock/issues/159#issuecomment-268249788
-fetchMock.fetchMock.Promise = Promise
+var realFetch = require('fetch-ponyfill')({ Promise: Promise })
+fetchMock.setImplementations(_.assign({ Promise: Promise }, realFetch))
 
 module.exports = {
 	fetchMock: fetchMock,
 	mockedFetch: fetchMock.fetchMock
-} 
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "fetch-ponyfill": "^3.0.2",
-    "fetch-mock": "^5.8.0",
+    "fetch-mock": "^5.9.4",
     "lodash": "^4.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.1",
   "description": "Common util to mock fetch requests in resin tests",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/resin-io-modules/resin-fetch-mock.git"
+  },
   "scripts": {},
   "keywords": [ "test", "fetch", "mock", "mocking" ],
   "author": "Eugene Mirotin <eugene@resin.io>",


### PR DESCRIPTION
Fetch-mock has now fixed lots of the issues that made setup messier and more painful - this PR updates this module tidy things up and remove the unnecessary workarounds.

I've tested this with `npm link` in my local `resin-request`, everything seems to work fine with just this now.